### PR TITLE
Require admin JWT role checks; normalize dates/times and fix bookings/stats queries

### DIFF
--- a/netlify/functions/admin-bookings.js
+++ b/netlify/functions/admin-bookings.js
@@ -28,7 +28,10 @@ function authz(event) {
   const h = event.headers?.authorization || event.headers?.Authorization || "";
   const m = h.match(/^Bearer\s+(.+)$/i);
   if (!m) return null;
-  try { return jwt.verify(m[1], process.env.ADMIN_JWT_SECRET); }
+  try {
+    const payload = jwt.verify(m[1], process.env.ADMIN_JWT_SECRET);
+    return payload?.role === "admin" || payload?.role === "owner" ? payload : null;
+  }
   catch { return null; }
 }
 
@@ -75,12 +78,15 @@ export async function handler(event) {
     const whereSql = where.length ? `WHERE ${where.join(" AND ")}` : "";
 
     params.push(limit);
+    const limitIdx = params.length;
     const rows = await sql.query(
   `
   SELECT order_id, name, phone, vehicle, service,
          date, time, visit, address, price, created_at
+  FROM kleenkars_bookings
   ${whereSql}
-  LIMIT $1
+  ORDER BY created_at DESC
+  LIMIT $${limitIdx}
   `,
   params
 );

--- a/netlify/functions/admin-services.js
+++ b/netlify/functions/admin-services.js
@@ -1,5 +1,6 @@
 // netlify/functions/admin-services.js
 import { neon, neonConfig } from "@neondatabase/serverless";
+import jwt from "jsonwebtoken";
 neonConfig.fetchConnectionCache = true;
 
 const ok = (obj) => ({
@@ -33,7 +34,14 @@ function needAuth(event){
 }
 function authorize(event){
   const auth = event.headers.authorization || event.headers.Authorization || "";
-  return auth.startsWith("Bearer ") && !!auth.slice(7).trim();
+  const m = auth.match(/^Bearer\s+(.+)$/i);
+  if (!m) return false;
+  try {
+    const payload = jwt.verify(m[1], process.env.ADMIN_JWT_SECRET);
+    return payload?.role === "admin" || payload?.role === "owner";
+  } catch {
+    return false;
+  }
 }
 function normInt(v){
   if (v === null || v === undefined || v === "") return null;

--- a/netlify/functions/admin-stats.js
+++ b/netlify/functions/admin-stats.js
@@ -18,7 +18,12 @@ const authz = (event, secret) => {
   const h = event.headers?.authorization || event.headers?.Authorization || "";
   const m = h.match(/^Bearer\s+(.+)$/i);
   if (!m) return null;
-  try { return jwt.verify(m[1], secret); } catch { return null; }
+  try {
+    const payload = jwt.verify(m[1], secret);
+    return payload?.role === "admin" || payload?.role === "owner" ? payload : null;
+  } catch {
+    return null;
+  }
 };
 
 export const handler = async (event) => {
@@ -38,7 +43,7 @@ export const handler = async (event) => {
     const from  = (qs.from  || "").trim();              // day: YYYY-MM-DD | month: YYYY-MM | year: YYYY
     const to    = (qs.to    || "").trim();
 
-    // --- Build WHERE for the selected window (Asia/Kolkata local time)
+    // --- Build WHERE for the selected window
     const where = [];
     const p = [];
     let fmt = "YYYY-MM";
@@ -46,42 +51,47 @@ export const handler = async (event) => {
     if (group === "year")  fmt = "YYYY";
 
     if (group === "day") {
-      if (from) { p.push(from); where.push(`(datetime AT TIME ZONE 'Asia/Kolkata')::date >= $${p.length}::date`); }
-      if (to)   { p.push(to);   where.push(`(datetime AT TIME ZONE 'Asia/Kolkata')::date <= $${p.length}::date`); }
+      if (from) { p.push(from); where.push(`dt_local::date >= $${p.length}::date`); }
+      if (to)   { p.push(to);   where.push(`dt_local::date <= $${p.length}::date`); }
     } else if (group === "month") {
-      if (from) { p.push(from); where.push(`(datetime AT TIME ZONE 'Asia/Kolkata') >= date_trunc('month', to_date($${p.length}, 'YYYY-MM'))`); }
-      if (to)   { p.push(to);   where.push(`(datetime AT TIME ZONE 'Asia/Kolkata') <  (date_trunc('month', to_date($${p.length}, 'YYYY-MM')) + INTERVAL '1 month')`); }
+      if (from) { p.push(from); where.push(`dt_local >= date_trunc('month', to_date($${p.length}, 'YYYY-MM'))`); }
+      if (to)   { p.push(to);   where.push(`dt_local <  (date_trunc('month', to_date($${p.length}, 'YYYY-MM')) + INTERVAL '1 month')`); }
     } else if (group === "year") {
-      if (from) { p.push(from); where.push(`(datetime AT TIME ZONE 'Asia/Kolkata') >= make_date($${p.length}::int, 1, 1)`); }
-      if (to)   { p.push(to);   where.push(`(datetime AT TIME ZONE 'Asia/Kolkata') <  make_date(($${p.length}::int + 1), 1, 1)`); }
+      if (from) { p.push(from); where.push(`dt_local >= make_date($${p.length}::int, 1, 1)`); }
+      if (to)   { p.push(to);   where.push(`dt_local <  make_date(($${p.length}::int + 1), 1, 1)`); }
     }
     const whereSql = where.length ? `WHERE ${where.join(" AND ")}` : "";
 
     // Base rows in window with safe price
-    const base = `
-      WITH base AS (
-        SELECT
-          (datetime AT TIME ZONE 'Asia/Kolkata') AS dt_local,
-          name, phone, vehicle, service,
-          COALESCE(
-            price,
-            CASE WHEN service ~ '\\d'
-                 THEN NULLIF(regexp_replace(service, '.*?(\\d+).*', '\\1'), '')::int
-                 ELSE 0
-            END
-          ) AS price_int
-        FROM bookings
-        ${whereSql}
-      )
+    const baseBody = `
+      SELECT
+        CASE
+          WHEN date ~ '^\\d{4}-\\d{2}-\\d{2}$' AND time ~ '^\\d{2}:\\d{2}$'
+            THEN to_timestamp(date || ' ' || time, 'YYYY-MM-DD HH24:MI')
+          WHEN date ~ '^\\d{4}-\\d{2}-\\d{2}$'
+            THEN to_timestamp(date || ' 00:00', 'YYYY-MM-DD HH24:MI')
+          ELSE NULL
+        END AS dt_local,
+        name, phone, vehicle, service,
+        COALESCE(
+          price,
+          CASE WHEN service ~ '\\d'
+               THEN NULLIF(regexp_replace(service, '.*?(\\d+).*', '\\1'), '')::int
+               ELSE 0
+          END
+        ) AS price_int
+      FROM kleenkars_bookings
     `;
 
     // 1) Trend points (grouped)
     const trendQ = `
-      ${base}
+      WITH base AS (${baseBody})
       SELECT to_char(dt_local, '${fmt}') AS label,
              SUM(price_int)::int AS total,
              COUNT(*)::int       AS count
       FROM base
+      WHERE dt_local IS NOT NULL
+      ${whereSql}
       GROUP BY 1
       ORDER BY 1
     `;
@@ -89,21 +99,25 @@ export const handler = async (event) => {
 
     // 2) Totals (for selected window)
     const totalsQ = `
-      ${base}
+      WITH base AS (${baseBody})
       SELECT COALESCE(SUM(price_int),0)::int AS total,
              COUNT(*)::int AS count
       FROM base
+      WHERE dt_local IS NOT NULL
+      ${whereSql}
     `;
     const totals = (await sql.query(totalsQ, p))[0] || { total: 0, count: 0 };
     const avg_ticket = totals.count ? Math.round(totals.total / totals.count) : 0;
 
     // 3) By service
     const byServiceQ = `
-      ${base}
+      WITH base AS (${baseBody})
       SELECT service AS label,
              SUM(price_int)::int AS total,
              COUNT(*)::int AS count
       FROM base
+      WHERE dt_local IS NOT NULL
+      ${whereSql}
       GROUP BY service
       ORDER BY total DESC NULLS LAST
       LIMIT 8
@@ -112,11 +126,13 @@ export const handler = async (event) => {
 
     // 4) By vehicle
     const byVehicleQ = `
-      ${base}
+      WITH base AS (${baseBody})
       SELECT vehicle AS label,
              SUM(price_int)::int AS total,
              COUNT(*)::int AS count
       FROM base
+      WHERE dt_local IS NOT NULL
+      ${whereSql}
       GROUP BY vehicle
       ORDER BY total DESC NULLS LAST
     `;
@@ -124,11 +140,13 @@ export const handler = async (event) => {
 
     // 5) Hour-of-day histogram (0..23)
     const byHourQ = `
-      ${base}
+      WITH base AS (${baseBody})
       SELECT EXTRACT(HOUR FROM dt_local)::int AS hour,
              SUM(price_int)::int AS total,
              COUNT(*)::int AS count
       FROM base
+      WHERE dt_local IS NOT NULL
+      ${whereSql}
       GROUP BY 1
       ORDER BY 1
     `;
@@ -136,11 +154,13 @@ export const handler = async (event) => {
 
     // 6) Day-of-week histogram (0=Sunday..6=Saturday)
     const byDowQ = `
-      ${base}
+      WITH base AS (${baseBody})
       SELECT EXTRACT(DOW FROM dt_local)::int AS dow,
              SUM(price_int)::int AS total,
              COUNT(*)::int AS count
       FROM base
+      WHERE dt_local IS NOT NULL
+      ${whereSql}
       GROUP BY 1
       ORDER BY 1
     `;

--- a/netlify/functions/admin-updateBooking.js
+++ b/netlify/functions/admin-updateBooking.js
@@ -1,5 +1,6 @@
 // netlify/functions/admin-updateBooking.js
 import { neon } from "@netlify/neon";
+import jwt from "jsonwebtoken";
 
 const ok = (obj) => ({
   statusCode: 200,
@@ -38,7 +39,16 @@ function computePrice(vehicle, service, visit){
 export async function handler(event){
   if (event.httpMethod === "OPTIONS") return ok({ ok:true });
   const auth = event.headers.authorization || event.headers.Authorization || "";
-  if (!auth.startsWith("Bearer ") || !auth.slice(7).trim()) return err(401, "Unauthorized");
+  const m = auth.match(/^Bearer\s+(.+)$/i);
+  if (!m) return err(401, "Unauthorized");
+  try {
+    const payload = jwt.verify(m[1], process.env.ADMIN_JWT_SECRET);
+    if (!(payload?.role === "admin" || payload?.role === "owner")) {
+      return err(401, "Unauthorized");
+    }
+  } catch {
+    return err(401, "Unauthorized");
+  }
 
   try{
     const body = JSON.parse(event.body || "{}");

--- a/netlify/functions/customer-updateBooking.js
+++ b/netlify/functions/customer-updateBooking.js
@@ -19,6 +19,18 @@ function computePrice(v, s, visit){
   if(visit === "Home Visit") p += HOME_SURCHARGE;
   return p;
 }
+function normDate(v){
+  const d = new Date(String(v ?? ""));
+  if (Number.isNaN(d.getTime())) return "";
+  return d.toISOString().split("T")[0];
+}
+function normTime(v){
+  const s = String(v ?? "").trim();
+  const m = s.match(/^([01]?\d|2[0-3]):([0-5]\d)$/);
+  if (!m) return "";
+  const hh = String(Number(m[1])).padStart(2, "0");
+  return `${hh}:${m[2]}`;
+}
 
 export async function handler(event){
   if(event.httpMethod !== "POST") return json(405, { ok:false, error:"Method not allowed" });
@@ -36,13 +48,9 @@ export async function handler(event){
     address = String(address||"").trim().slice(0,500);
 
     // normalize date/time
-    try { date = new Date(String(date)).toISOString().split("T")[0]; } catch {}
-    try {
-      const d = new Date(`1970-01-01T${String(time)}`);
-      const hh = String(d.getUTCHours()).padStart(2,"0");
-      const mm = String(d.getUTCMinutes()).padStart(2,"0");
-      time = `${hh}:${mm}`;
-    } catch {}
+    date = normDate(date);
+    time = normTime(time);
+    if (!date || !time) return json(400, { ok:false, error:"Invalid date/time" });
 
     const price = computePrice(vehicle, service, visit);
     if(price == null) return json(400, { ok:false, error:`${service} not available for ${vehicle}` });

--- a/netlify/functions/saveBooking.js
+++ b/netlify/functions/saveBooking.js
@@ -18,15 +18,17 @@ const HOME_SURCHARGE = 50;
 function normText(v, max = 500) { return String(v ?? "").trim().slice(0, max); }
 function normPhone(v) { return String(v || "").replace(/\D/g, "").slice(0, 15); }
 function normDate(v) {
-  try { return new Date(v).toISOString().split("T")[0]; } catch { return ""; }
+  const d = new Date(v);
+  if (Number.isNaN(d.getTime())) return "";
+  return d.toISOString().split("T")[0];
 }
 function normTime(v) {
-  try {
-    const d = new Date(`1970-01-01T${v}`);
-    const hh = String(d.getUTCHours()).padStart(2, "0");
-    const mm = String(d.getUTCMinutes()).padStart(2, "0");
-    return `${hh}:${mm}`;
-  } catch { return ""; }
+  const s = String(v ?? "").trim();
+  const m = s.match(/^([01]?\d|2[0-3]):([0-5]\d)$/);
+  if (!m) return "";
+  const hh = String(Number(m[1])).padStart(2, "0");
+  const mm = m[2];
+  return `${hh}:${mm}`;
 }
 
 // Reuse gaps: 1,2,3… find smallest missing order_id


### PR DESCRIPTION
### Motivation

- Harden admin endpoints by enforcing JWT-based role authorization for `admin`/`owner` roles. 
- Normalize date/time parsing and validation across booking endpoints to avoid ambiguous `Date` handling. 
- Align SQL usage with the canonical `kleenkars_bookings` table and improve query correctness and ordering for admin reports.

### Description

- Added `jsonwebtoken` usage and role checks to admin handlers (`admin-bookings`, `admin-services`, `admin-stats`, `admin-updateBooking`) to verify the bearer token and allow only payloads with `role` equal to `admin` or `owner`.
- Fixed `admin-bookings` SQL to select from `kleenkars_bookings`, added `ORDER BY created_at DESC` and parameterized the `LIMIT` correctly.
- Reworked `admin-stats` to build `dt_local` from the `date`/`time` columns, switched queries to use `dt_local` (removed explicit `AT TIME ZONE 'Asia/Kolkata'` usage), and added `WHERE dt_local IS NOT NULL` to aggregations.
- Tightened booking input normalization: introduced `normDate` and `normTime` helpers and stronger validation in `customer-updateBooking` and `saveBooking`, and improved price calculation/validation where applicable.
- Replaced several fragile `Date`-based stringification attempts with explicit regex-based time normalization and ISO date validation to ensure consistent stored values.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df8f78b8388326b1ebba40623d359b)